### PR TITLE
Update 2022-05-22-why-acn.md for Risk Attestation

### DIFF
--- a/_posts/2022-05-22-why-acn.md
+++ b/_posts/2022-05-22-why-acn.md
@@ -43,10 +43,6 @@ It may be important to call out that the levels of risk attestation can be viewe
 ## Examples:
 
 ```
-. r Rename method to Applesauce
-^ r Extract method Applesauce 
-! r replace the algorithm method
-@ r edit to the lambda in the cloud and I don't know if it works or not and will break my pipeline
 ```
 
 ### About "unknown" risks


### PR DESCRIPTION
Changes brought forth from a software conversation over lunch. 

// Hopefully includes some humorous verbiage that makes it obvious what each code symbol, when it is stated, is trying to indicate! 